### PR TITLE
Add WooCommerce check and settings link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
-# Product Recommendation Plugin
+# AI Product Recommendation Plugin
 
-This plugin provides a minimal product recommendation system.
+This plugin provides an MVP product recommendation system powered by OpenAI's ChatGPT API.
 
 ## Features
 
-- Registers a custom post type **Product**.
-- Adds meta boxes for **Product Name** and **Product Category** fields.
-- Shortcode `[product_recommendations category="CATEGORY"]` displays products matching the category.
+- Shortcode `[ai_product_recommendations]` generates personalized product suggestions.
+- Settings page to configure the OpenAI API key, prompt template, and number of products to display.
+- Recommendations are displayed in a responsive list.
+- Requires WooCommerce to be installed and active.
 
 ## Usage
 
-1. Copy `product-recommendation-plugin.php` to your WordPress plugin directory.
-2. Activate the plugin from the WordPress admin.
-3. Add products using the **Products** menu.
-4. Use the shortcode in posts or pages to display recommendations by category.
+1. Copy the plugin files to your WordPress `wp-content/plugins` directory.
+2. Activate **AI Product Recommendation Plugin** from the admin Plugins screen.
+3. Visit **Settings > AI Recommendations** to enter your API key and customize the prompt.
+4. Insert the shortcode into any post or page.
+5. A **Settings** link is available on the Plugins page for quick access.
 
+The prompt template supports `{preferences}` and `{count}` placeholders which will be replaced with user preference data and the number of products to show.

--- a/assets/css/ai-product-recommendation.css
+++ b/assets/css/ai-product-recommendation.css
@@ -1,0 +1,15 @@
+.ai-prp-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.ai-prp-list li {
+    background: #f5f5f5;
+    margin: 0 10px 10px 0;
+    padding: 10px;
+    border-radius: 4px;
+    flex: 1 0 45%;
+}

--- a/includes/class-ai-product-recommendation.php
+++ b/includes/class-ai-product-recommendation.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Main plugin class for AI Product Recommendation Plugin.
+ *
+ * @package AI_PRP
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * AI Product Recommendation Plugin class.
+ */
+class AI_Product_Recommendation_Plugin {
+
+    /**
+     * Option name for storing settings.
+     *
+     * @var string
+     */
+    private $option_name = 'ai_prp_settings';
+
+    /**
+     * Constructor. Hooks into WordPress actions.
+     */
+    public function __construct() {
+        add_action( 'init', array( $this, 'load_textdomain' ) );
+        add_action( 'init', array( $this, 'register_shortcode' ) );
+        add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+    }
+
+    /**
+     * Load plugin textdomain for translations.
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'ai-prp', false, dirname( plugin_basename( __FILE__ ) ) . '/../languages' );
+    }
+
+    /**
+     * Register the shortcode.
+     */
+    public function register_shortcode() {
+        add_shortcode( 'ai_product_recommendations', array( $this, 'shortcode_callback' ) );
+    }
+
+    /**
+     * Enqueue front-end assets.
+     */
+    public function enqueue_assets() {
+        wp_enqueue_style( 'ai-prp-style', plugins_url( '../assets/css/ai-product-recommendation.css', __FILE__ ), array(), '1.0.0' );
+    }
+
+    /**
+     * Add settings page under the Settings menu.
+     */
+    public function add_settings_page() {
+        add_options_page(
+            __( 'AI Recommendations', 'ai-prp' ),
+            __( 'AI Recommendations', 'ai-prp' ),
+            'manage_options',
+            'ai-prp',
+            array( $this, 'settings_page' )
+        );
+    }
+
+    /**
+     * Register plugin settings using the Settings API.
+     */
+    public function register_settings() {
+        register_setting(
+            'ai_prp_settings',
+            $this->option_name,
+            array( $this, 'sanitize_settings' )
+        );
+
+        add_settings_section(
+            'ai_prp_main',
+            __( 'API Settings', 'ai-prp' ),
+            '__return_false',
+            'ai_prp'
+        );
+
+        add_settings_field( 'api_key', __( 'OpenAI API Key', 'ai-prp' ), array( $this, 'field_api_key' ), 'ai_prp', 'ai_prp_main' );
+        add_settings_field( 'prompt', __( 'Prompt Template', 'ai-prp' ), array( $this, 'field_prompt' ), 'ai_prp', 'ai_prp_main' );
+        add_settings_field( 'count', __( 'Number of Products', 'ai-prp' ), array( $this, 'field_count' ), 'ai_prp', 'ai_prp_main' );
+    }
+
+    /**
+     * Sanitize settings before saving.
+     *
+     * @param array $input Raw input values.
+     * @return array Sanitized values.
+     */
+    public function sanitize_settings( $input ) {
+        $new              = array();
+        $new['api_key']   = isset( $input['api_key'] ) ? sanitize_text_field( $input['api_key'] ) : '';
+        $new['prompt']    = isset( $input['prompt'] ) ? sanitize_textarea_field( $input['prompt'] ) : '';
+        $new['count']     = isset( $input['count'] ) ? absint( $input['count'] ) : 3;
+        return $new;
+    }
+
+    /**
+     * Render API key field.
+     */
+    public function field_api_key() {
+        $options = get_option( $this->option_name );
+        ?>
+        <input type="text" name="<?php echo esc_attr( $this->option_name ); ?>[api_key]" value="<?php echo isset( $options['api_key'] ) ? esc_attr( $options['api_key'] ) : ''; ?>" class="regular-text" />
+        <?php
+    }
+
+    /**
+     * Render prompt template field.
+     */
+    public function field_prompt() {
+        $options = get_option( $this->option_name );
+        ?>
+        <textarea name="<?php echo esc_attr( $this->option_name ); ?>[prompt]" rows="5" cols="50" class="large-text"><?php echo isset( $options['prompt'] ) ? esc_textarea( $options['prompt'] ) : ''; ?></textarea>
+        <p class="description"><?php esc_html_e( 'Use {preferences} and {count} placeholders.', 'ai-prp' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Render count field.
+     */
+    public function field_count() {
+        $options = get_option( $this->option_name );
+        ?>
+        <input type="number" min="1" max="10" name="<?php echo esc_attr( $this->option_name ); ?>[count]" value="<?php echo isset( $options['count'] ) ? absint( $options['count'] ) : 3; ?>" />
+        <?php
+    }
+
+    /**
+     * Display settings page content.
+     */
+    public function settings_page() {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'AI Product Recommendations', 'ai-prp' ); ?></h1>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields( 'ai_prp_settings' );
+                do_settings_sections( 'ai_prp' );
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Shortcode callback to display product recommendations.
+     *
+     * @return string HTML output.
+     */
+    public function shortcode_callback() {
+        $options = get_option( $this->option_name );
+        $count   = isset( $options['count'] ) ? absint( $options['count'] ) : 3;
+        $prompt  = isset( $options['prompt'] ) ? $options['prompt'] : '';
+
+        $preferences = '';
+        if ( ! empty( $_COOKIE['ai_prp_preferences'] ) ) {
+            $preferences = sanitize_text_field( wp_unslash( $_COOKIE['ai_prp_preferences'] ) );
+        }
+
+        if ( is_user_logged_in() ) {
+            $user_pref = get_user_meta( get_current_user_id(), 'ai_prp_preferences', true );
+            if ( $user_pref ) {
+                $preferences .= ' ' . sanitize_text_field( $user_pref );
+            }
+        }
+
+        if ( empty( $prompt ) ) {
+            $prompt = __( 'Recommend {count} products for a user interested in {preferences}. Return only product names separated by commas.', 'ai-prp' );
+        }
+
+        $prompt = str_replace( array( '{count}', '{preferences}' ), array( $count, $preferences ), $prompt );
+
+        $recommendations = $this->fetch_recommendations( $prompt, isset( $options['api_key'] ) ? $options['api_key'] : '' );
+        if ( is_wp_error( $recommendations ) ) {
+            return '';
+        }
+
+        $items  = array_map( 'trim', explode( ',', $recommendations ) );
+        $output = '<ul class="ai-prp-list">';
+        foreach ( $items as $item ) {
+            if ( '' !== $item ) {
+                $output .= '<li>' . esc_html( $item ) . '</li>';
+            }
+        }
+        $output .= '</ul>';
+
+        return $output;
+    }
+
+    /**
+     * Call OpenAI API to fetch recommendations.
+     *
+     * @param string $prompt  Prompt to send to the API.
+     * @param string $api_key API key.
+     * @return string|WP_Error Response string or error.
+     */
+    private function fetch_recommendations( $prompt, $api_key ) {
+        if ( empty( $api_key ) ) {
+            return new WP_Error( 'no_api_key', __( 'API key not set.', 'ai-prp' ) );
+        }
+
+        $args = array(
+            'body'    => wp_json_encode(
+                array(
+                    'model'       => 'gpt-3.5-turbo',
+                    'messages'    => array(
+                        array(
+                            'role'    => 'user',
+                            'content' => $prompt,
+                        ),
+                    ),
+                    'temperature' => 0.7,
+                )
+            ),
+            'headers' => array(
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer ' . $api_key,
+            ),
+            'timeout' => 30,
+        );
+
+        $response = wp_remote_post( 'https://api.openai.com/v1/chat/completions', $args );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+            return new WP_Error( 'api_error', __( 'Unexpected API response.', 'ai-prp' ) );
+        }
+
+        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( empty( $body['choices'][0]['message']['content'] ) ) {
+            return new WP_Error( 'api_error', __( 'Invalid API response.', 'ai-prp' ) );
+        }
+
+        return $body['choices'][0]['message']['content'];
+    }
+}

--- a/product-recommendation-plugin.php
+++ b/product-recommendation-plugin.php
@@ -1,111 +1,64 @@
 <?php
-/*
-Plugin Name: Product Recommendation Plugin
-Description: MVP product recommendation system. Registers a Product custom post type and provides shortcode for recommendations by category.
-Version: 1.0.0
-Author: OpenAI Codex
-*/
+/**
+ * Plugin Name: AI Product Recommendation Plugin
+ * Description: MVP product recommendation system using ChatGPT. Provides a shortcode for displaying recommendations.
+ * Version: 1.0.0
+ * Author: OpenAI Codex
+ * Text Domain: ai-prp
+ * Domain Path: /languages
+ *
+ * Example usage of shortcode: [ai_product_recommendations]
+ * Requires Plugins: WooCommerce
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly.
 }
 
-// Register custom post type
-function prp_register_product_cpt() {
-    $labels = array(
-        'name'               => __( 'Products', 'prp' ),
-        'singular_name'      => __( 'Product', 'prp' ),
-        'add_new'            => __( 'Add New Product', 'prp' ),
-        'add_new_item'       => __( 'Add New Product', 'prp' ),
-        'edit_item'          => __( 'Edit Product', 'prp' ),
-        'new_item'           => __( 'New Product', 'prp' ),
-        'all_items'          => __( 'All Products', 'prp' ),
-        'view_item'          => __( 'View Product', 'prp' ),
-        'search_items'       => __( 'Search Products', 'prp' ),
-        'not_found'          => __( 'No products found', 'prp' ),
-        'not_found_in_trash' => __( 'No products found in Trash', 'prp' ),
-        'menu_name'          => __( 'Products', 'prp' )
-    );
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-ai-product-recommendation.php';
 
-    $args = array(
-        'labels'             => $labels,
-        'public'             => true,
-        'has_archive'        => true,
-        'supports'           => array( 'title', 'editor' ),
-        'show_in_rest'       => true,
-    );
-
-    register_post_type( 'product', $args );
-}
-add_action( 'init', 'prp_register_product_cpt' );
-
-// Add meta boxes for product fields
-function prp_add_product_metaboxes() {
-    add_meta_box( 'prp_product_name', __( 'Product Name', 'prp' ), 'prp_product_name_callback', 'product', 'normal', 'default' );
-    add_meta_box( 'prp_product_category', __( 'Product Category', 'prp' ), 'prp_product_category_callback', 'product', 'normal', 'default' );
-}
-add_action( 'add_meta_boxes', 'prp_add_product_metaboxes' );
-
-function prp_product_name_callback( $post ) {
-    $value = get_post_meta( $post->ID, '_prp_product_name', true );
-    echo '<input type="text" name="prp_product_name" value="' . esc_attr( $value ) . '" style="width:100%;" />';
+/**
+ * Show an admin notice if WooCommerce is not active.
+ */
+function ai_prp_wc_missing_notice() {
+    echo '<div class="notice notice-error"><p>' . esc_html__( 'AI Product Recommendation Plugin requires WooCommerce to be installed and active.', 'ai-prp' ) . '</p></div>';
 }
 
-function prp_product_category_callback( $post ) {
-    $value = get_post_meta( $post->ID, '_prp_product_category', true );
-    echo '<input type="text" name="prp_product_category" value="' . esc_attr( $value ) . '" style="width:100%;" />';
+/**
+ * Check for WooCommerce dependency.
+ *
+ * @return bool Whether WooCommerce is active.
+ */
+function ai_prp_check_woocommerce() {
+    if ( class_exists( 'WooCommerce' ) ) {
+        return true;
+    }
+
+    add_action( 'admin_notices', 'ai_prp_wc_missing_notice' );
+    return false;
 }
 
-// Save meta box data
-function prp_save_product_meta( $post_id ) {
-    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+/**
+ * Initialize the plugin.
+ */
+function ai_prp_init() {
+    if ( ! ai_prp_check_woocommerce() ) {
         return;
     }
 
-    if ( isset( $_POST['prp_product_name'] ) ) {
-        update_post_meta( $post_id, '_prp_product_name', sanitize_text_field( $_POST['prp_product_name'] ) );
-    }
-
-    if ( isset( $_POST['prp_product_category'] ) ) {
-        update_post_meta( $post_id, '_prp_product_category', sanitize_text_field( $_POST['prp_product_category'] ) );
-    }
+    new AI_Product_Recommendation_Plugin();
 }
-add_action( 'save_post_product', 'prp_save_product_meta' );
+add_action( 'plugins_loaded', 'ai_prp_init' );
 
-// Shortcode for displaying product recommendations by category
-function prp_product_recommendations_shortcode( $atts ) {
-    $atts = shortcode_atts( array(
-        'category' => '',
-    ), $atts, 'product_recommendations' );
-
-    if ( empty( $atts['category'] ) ) {
-        return '';
-    }
-
-    $args = array(
-        'post_type'  => 'product',
-        'meta_key'   => '_prp_product_category',
-        'meta_value' => sanitize_text_field( $atts['category'] ),
-        'posts_per_page' => -1,
-    );
-
-    $query = new WP_Query( $args );
-
-    if ( ! $query->have_posts() ) {
-        return '<p>No product recommendations found.</p>';
-    }
-
-    $output = '<ul class="prp-recommendations">';
-    while ( $query->have_posts() ) {
-        $query->the_post();
-        $name = get_post_meta( get_the_ID(), '_prp_product_name', true );
-        $output .= '<li>' . esc_html( $name ? $name : get_the_title() ) . '</li>';
-    }
-    $output .= '</ul>';
-
-    wp_reset_postdata();
-    return $output;
+/**
+ * Add a Settings link on the Plugins page.
+ *
+ * @param string[] $links Existing links.
+ * @return string[] Modified links.
+ */
+function ai_prp_action_links( $links ) {
+    $url = admin_url( 'options-general.php?page=ai-prp' );
+    $links[] = '<a href="' . esc_url( $url ) . '">' . esc_html__( 'Settings', 'ai-prp' ) . '</a>';
+    return $links;
 }
-add_shortcode( 'product_recommendations', 'prp_product_recommendations_shortcode' );
-
-?>
+add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'ai_prp_action_links' );


### PR DESCRIPTION
## Summary
- require WooCommerce for the plugin to run
- display a notice when WooCommerce is missing
- add a quick Settings link on the Plugins page
- document the WooCommerce requirement in the README

## Testing
- `php -l product-recommendation-plugin.php` *(fails: `php` command not found)*
- `php -l includes/class-ai-product-recommendation.php` *(fails: `php` command not found)*